### PR TITLE
Lower minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nexoscp/NilAwayToCheckStyle
 
-go 1.21.4
+go 1.20


### PR DESCRIPTION
* Since this is build/ci/cd tooling, it should generally build with currently supported versions (being the last two).
* Use 1.20 as uber nilaway is using that as well.